### PR TITLE
Fix/add-refresh-token-hook

### DIFF
--- a/documents/token-refresh-implementation-pr.md
+++ b/documents/token-refresh-implementation-pr.md
@@ -1,0 +1,54 @@
+# Token Refresh Implementation
+
+## Overview
+
+토큰 갱신 로직과 401 에러 처리를 위한 HTTP 클라이언트 구현
+
+## Changes
+
+- `ky` 클라이언트에 토큰 갱신 로직 추가
+- 토큰 갱신 중 발생하는 race condition 처리를 위한 큐 시스템 구현
+- React 외부에서 토큰 상태 관리를 위한 Jotai store 구현
+
+## Implementation Details
+
+### Token Refresh Flow
+
+1. `afterResponse` 훅에서 401 응답 감지
+2. 토큰 갱신 중이 아닌 경우에만 갱신 시도
+3. 갱신 중인 경우 요청을 큐에 추가
+4. 갱신 성공 시 큐의 요청들 재시도
+5. 갱신 실패 시 로그아웃 처리
+
+### Queue System
+
+- `refreshPromise`: 현재 진행 중인 토큰 갱신 요청 추적
+- `requestQueue`: 토큰 갱신 중 발생한 요청들을 저장
+- `addToQueue`: 새로운 요청을 큐에 추가
+- `executeQueue`: 토큰 갱신 성공 후 큐의 요청들 실행
+- `clearQueue`: 토큰 갱신 실패 시 큐 초기화
+
+### Error Handling
+
+- 토큰 갱신 실패 시 `UnauthorizedError` 발생
+- 네트워크 오류 및 타임아웃 처리
+- HTTP 상태 코드별 적절한 에러 클래스 매핑
+
+## Testing
+
+- [ ] 토큰 갱신 성공 케이스
+- [ ] 토큰 갱신 실패 케이스
+- [ ] 동시 요청 처리
+- [ ] 네트워크 오류 처리
+
+## Related Issues
+
+## Breaking Changes
+
+없음
+
+## Notes
+
+- `ky` 클라이언트의 `afterResponse` 훅을 사용하여 401 응답을 인터셉트
+- Jotai의 `createStore`를 사용하여 React 외부에서 상태 관리
+- 토큰 갱신 중 발생하는 요청들은 큐에서 대기 후 일괄 처리

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -1,5 +1,7 @@
-import ky, { HTTPError } from 'ky';
+import ky, { HTTPError, KyResponse, NormalizedOptions, KyRequest } from 'ky';
 import { match, P } from 'ts-pattern';
+import { createStore } from 'jotai/vanilla';
+import { authActions, authAtom } from '../auth/store';
 import {
   UnauthorizedError,
   ForbiddenError,
@@ -13,26 +15,91 @@ import {
   TimeoutError,
 } from '../errors/http';
 
-const handleError = async (error: unknown) => {
-  if (error instanceof HTTPError) {
-    const response = error.response;
-    const request = error.request;
-    const options = error.options;
+const store = createStore();
 
-    throw match(response.status)
-      .with(401, () => new UnauthorizedError(response, request, options))
-      .with(403, () => new ForbiddenError(response, request, options))
-      .with(404, () => new NotFoundError(response, request, options))
-      .with(409, () => new ConflictError(response, request, options))
-      .with(400, () => new BadRequestError(response, request, options))
-      .with(422, () => new ValidationError(response, request, options))
-      .with(503, () => new ServiceUnavailableError(response, request, options))
-      .with(
-        P.number.between(500, 599),
-        () => new ServerError(response, request, options)
-      )
-      .otherwise(() => new ServerError(response, request, options));
+let refreshPromise: Promise<void> | null = null;
+const requestQueue: (() => Promise<any>)[] = [];
+
+const addToQueue = (request: () => Promise<any>) => {
+  return new Promise((resolve, reject) => {
+    requestQueue.push(() => request().then(resolve).catch(reject));
+  });
+};
+
+const executeQueue = () => {
+  const queue = [...requestQueue];
+  requestQueue.length = 0;
+
+  queue.forEach((request) => {
+    request();
+  });
+};
+
+const clearQueue = () => {
+  const queue = [...requestQueue];
+  requestQueue.length = 0;
+
+  queue.forEach((request) => {
+    // Ignore all the requests in the queue
+    request().catch(() => {});
+  });
+};
+
+const handleTokenRefresh = async (
+  request: KyRequest,
+  options: NormalizedOptions,
+  response: KyResponse
+): Promise<KyResponse> => {
+  if (response.status !== 401) {
+    return response;
   }
+
+  if (refreshPromise !== null) {
+    return addToQueue(() => client(request)) as Promise<KyResponse>;
+  }
+
+  try {
+    const { accessToken, refreshToken } = store.get(authAtom);
+    if (!refreshToken) throw new UnauthorizedError(response, request, options);
+
+    refreshPromise = ky
+      .post('auth/refresh', {
+        prefixUrl: 'http://localhost:8080',
+        json: {
+          accessToken,
+          refreshToken,
+        },
+      })
+      .json<{
+        apiResult: string;
+        data: {
+          accessToken: string;
+          refreshToken: string;
+        };
+      }>()
+      .then(async (response) => {
+        await store.set(authActions.setTokens, response.data);
+      })
+      .catch(() => {
+        throw new UnauthorizedError(response, request, options);
+      });
+
+    await refreshPromise;
+    executeQueue();
+    return client(request);
+  } catch (error) {
+    clearQueue();
+    await store.set(authActions.clearTokens);
+    throw error;
+  } finally {
+    refreshPromise = null;
+  }
+};
+
+const handleError = async (error: HTTPError): Promise<HTTPError> => {
+  const response = error.response;
+  const request = error.request;
+  const options = error.options;
 
   if (error instanceof TypeError) {
     if (error.message === 'Failed to fetch') {
@@ -43,16 +110,37 @@ const handleError = async (error: unknown) => {
     }
   }
 
-  throw error;
+  throw match(response.status)
+    .with(401, () => new UnauthorizedError(response, request, options))
+    .with(403, () => new ForbiddenError(response, request, options))
+    .with(404, () => new NotFoundError(response, request, options))
+    .with(409, () => new ConflictError(response, request, options))
+    .with(400, () => new BadRequestError(response, request, options))
+    .with(422, () => new ValidationError(response, request, options))
+    .with(503, () => new ServiceUnavailableError(response, request, options))
+    .with(
+      P.number.between(500, 599),
+      () => new ServerError(response, request, options)
+    )
+    .otherwise(() => new ServerError(response, request, options));
 };
 
 export const client = ky.create({
   prefixUrl: 'http://localhost:8080',
   hooks: {
+    beforeRequest: [
+      async (request) => {
+        const { accessToken } = store.get(authAtom);
+        if (accessToken) {
+          request.headers.set('Authorization', `Bearer ${accessToken}`);
+        }
+      },
+    ],
+    afterResponse: [handleTokenRefresh],
     beforeError: [handleError],
   },
   retry: {
-    limit: 3,
+    limit: 2,
     methods: ['get', 'put'],
     statusCodes: [408, 500, 502, 503, 504],
     delay: (attemptCount: number) => Math.min(1000 * 2 ** attemptCount, 10000),


### PR DESCRIPTION
# Token Refresh Implementation

## Overview

토큰 갱신 로직과 401 에러 처리를 위한 HTTP 클라이언트 구현

## Changes

- `ky` 클라이언트에 토큰 갱신 로직 추가
- 토큰 갱신 중 발생하는 race condition 처리를 위한 큐 시스템 구현
- React 외부에서 토큰 상태 관리를 위한 Jotai store 구현

## Implementation Details

### Token Refresh Flow

1. `afterResponse` 훅에서 401 응답 감지
2. 토큰 갱신 중이 아닌 경우에만 갱신 시도
3. 갱신 중인 경우 요청을 큐에 추가
4. 갱신 성공 시 큐의 요청들 재시도
5. 갱신 실패 시 로그아웃 처리

### Queue System

- `refreshPromise`: 현재 진행 중인 토큰 갱신 요청 추적
- `requestQueue`: 토큰 갱신 중 발생한 요청들을 저장
- `addToQueue`: 새로운 요청을 큐에 추가
- `executeQueue`: 토큰 갱신 성공 후 큐의 요청들 실행
- `clearQueue`: 토큰 갱신 실패 시 큐 초기화

### Error Handling

- 토큰 갱신 실패 시 `UnauthorizedError` 발생
- 네트워크 오류 및 타임아웃 처리
- HTTP 상태 코드별 적절한 에러 클래스 매핑

## Testing

- [ ] 토큰 갱신 성공 케이스
- [ ] 토큰 갱신 실패 케이스
- [ ] 동시 요청 처리
- [ ] 네트워크 오류 처리

## Related Issues

## Breaking Changes

없음

## Notes

- `ky` 클라이언트의 `afterResponse` 훅을 사용하여 401 응답을 인터셉트
- Jotai의 `createStore`를 사용하여 React 외부에서 상태 관리
- 토큰 갱신 중 발생하는 요청들은 큐에서 대기 후 일괄 처리
