### PR TITLE
에러 타입별 네비게이션 전략 구현

### DIFF
--- a/hooks/useRecoverFromError.ts
+++ b/hooks/useRecoverFromError.ts
@@ -20,6 +20,7 @@ export const useRecoverFromError = () => {
         shouldClearCache = true,
         shouldClearAuth = false,
         shouldClearNavigation = true,
+        navigationTarget = '/',
       } = details.args[0] || {};
 
       if (shouldClearCache) {
@@ -31,7 +32,7 @@ export const useRecoverFromError = () => {
       }
 
       if (shouldClearNavigation) {
-        router.replace('/');
+        router.replace(navigationTarget);
       }
     },
     [queryClient, clearTokens]

--- a/lib/errors/http.ts
+++ b/lib/errors/http.ts
@@ -9,6 +9,7 @@ export interface ResetOptions {
   shouldClearCache?: boolean;
   shouldClearAuth?: boolean;
   shouldClearNavigation?: boolean;
+  navigationTarget?: string;
 }
 
 export class UnauthorizedError extends HTTPError {

--- a/lib/errors/http.ts
+++ b/lib/errors/http.ts
@@ -27,6 +27,7 @@ export class UnauthorizedError extends HTTPError {
       shouldClearCache: true,
       shouldClearAuth: true,
       shouldClearNavigation: true,
+      navigationTarget: '/login',
     };
   }
 }
@@ -46,6 +47,7 @@ export class ForbiddenError extends HTTPError {
       shouldClearCache: true,
       shouldClearAuth: true,
       shouldClearNavigation: true,
+      navigationTarget: '/',
     };
   }
 }
@@ -103,6 +105,7 @@ export class BadRequestError extends HTTPError {
       shouldClearCache: false,
       shouldClearAuth: false,
       shouldClearNavigation: true,
+      navigationTarget: '/',
     };
   }
 }


### PR DESCRIPTION
## 개요

에러 발생 시 에러 타입에 따라 적절한 페이지로 네비게이션하는 기능을 구현했습니다.

## 주요 변경사항

### 1. 네비게이션 타겟 지원 추가

- `ResetOptions` 타입에 `navigationTarget` 필드 추가
- 에러 복구 훅에서 `navigationTarget` 사용하도록 수정
- 기본 네비게이션 타겟을 홈 페이지로 설정

### 2. 에러별 네비게이션 전략 구성

- `UnauthorizedError`: 로그인 페이지(`/login`)로 이동
  - 인증이 필요한 상황에서 사용자를 로그인 페이지로 안내
- `ForbiddenError`: 홈 페이지(`/`)로 이동
  - 권한이 없는 경우 안전한 페이지로 이동
- `BadRequestError`: 홈 페이지(`/`)로 이동
  - 잘못된 요청의 경우 초기 상태로 복구

## 커밋 히스토리

- a6630ed: feat: configure navigation targets for errors
- a7ae066: feat: add navigation target support to error recovery

## 테스트 방법

1. 인증 에러 (401) 발생 시

   - `/login` 페이지로 이동하는지 확인
   - 이동 후 에러 메시지가 적절히 표시되는지 확인

2. 권한 에러 (403) 발생 시

   - 홈 페이지(`/`)로 이동하는지 확인
   - 적절한 에러 메시지가 표시되는지 확인

3. 잘못된 요청 (400) 발생 시
   - 홈 페이지(`/`)로 이동하는지 확인
   - 에러 메시지가 표시되는지 확인

