### PR TITLE
에러 복구 시 type-safe 네비게이션 구현

### DIFF
--- a/app/login/index.tsx
+++ b/app/login/index.tsx
@@ -12,10 +12,7 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
 
   const handleReset = useCallback(
     async (resetOptions: ResetOptions) => {
-      await recoverFromError({
-        reason: 'imperative-api',
-        args: [resetOptions],
-      });
+      await recoverFromError(resetOptions);
       retry();
     },
     [recoverFromError, retry]

--- a/documents/implement-global-reset-on-error-pr.md
+++ b/documents/implement-global-reset-on-error-pr.md
@@ -1,0 +1,57 @@
+# 전역 에러 처리 구현
+
+## 개요
+
+에러 발생 시 앱의 상태를 안전하게 복구하고 사용자에게 적절한 피드백을 제공하는 기능을 구현했습니다.
+
+## 주요 변경사항
+
+### 1. 에러 복구 로직 개선
+
+- 에러 복구 훅 이름을 `useHandleReset`에서 `useRecoverFromError`로 변경하여 목적을 명확히 함
+- 각 에러 타입별 복구 전략(캐시, 인증, 네비게이션)을 명확하게 정의
+- 불필요한 코드와 import 정리
+
+### 2. 에러 바운더리 구조 개선
+
+- Expo Router의 기본 에러 바운더리를 활용하도록 변경
+- 중복된 `ErrorBoundaryProvider` 제거
+- 에러 복구 흐름을 단순화하고 명확하게 개선
+
+### 3. 네비게이션 전략 구현
+
+- 에러 상황별 적절한 네비게이션 처리 추가
+  - 인증 에러: 로그인 페이지로 이동
+  - 권한/잘못된 요청 에러: 홈 페이지로 이동
+
+## 커밋 히스토리
+
+- ec69a76: feat: navigate to home for error recovery
+- 1eb124c: feat: navigate to home page on bad request error
+- 8ea6d41: refactor: remove ErrorProvider and SuspenseProvider
+- ef85dc4: refactor: replace constant with env
+- caba411: refactor: improve error recovery flow
+- 22f71ef: refactor: remove ErrorBoundaryProvider in favor of Expo Router's ErrorBoundary
+- 94a096d: refactor: rename error recovery hook for clarity
+- 0b04185: feat: customize query cache, auth, navigation based on error types
+
+## 테스트 방법
+
+1. 인증이 필요한 API 호출 시 401 에러 발생
+
+   - 로그인 페이지로 이동하는지 확인
+   - 캐시와 인증 정보가 초기화되는지 확인
+
+2. 권한이 없는 API 호출 시 403 에러 발생
+
+   - 홈 페이지로 이동하는지 확인
+   - 캐시와 인증 정보가 초기화되는지 확인
+
+3. 잘못된 요청 시 400 에러 발생
+   - 홈 페이지로 이동하는지 확인
+   - 적절한 에러 메시지가 표시되는지 확인
+
+## 관련 이슈
+
+- #xxx 전역 에러 처리 구현
+- #xxx 에러 복구 전략 개선

--- a/documents/type-safe-navigation-pr.md
+++ b/documents/type-safe-navigation-pr.md
@@ -1,0 +1,41 @@
+# 에러 복구 시 type-safe 네비게이션 구현
+
+## 개요
+
+에러 복구 시 네비게이션 처리에 expo-router의 Route 타입을 적용하여 타입 안전성을 개선했습니다.
+
+## 주요 변경사항
+
+### 1. expo-router Route 타입 적용
+
+- `ResetOptions`의 `navigationTarget` 타입을 string에서 expo-router의 Route 타입으로 변경
+- 타입 안전성 확보로 잘못된 경로 지정 방지
+- 자동 완성 지원으로 개발 편의성 향상
+
+### 2. 타입 캐스팅 제거
+
+- `useRecoverFromError` 훅에서 불필요한 타입 캐스팅 제거
+- 타입 시스템을 통한 경로 유효성 검증
+
+## 기대효과
+
+- 잘못된 경로로의 네비게이션 시도를 컴파일 타임에 방지
+- 리팩토링 시 경로 변경에 대한 안전성 확보
+- 개발자 경험 개선 (자동 완성, 타입 체크)
+
+## 커밋 히스토리
+
+- a6630ed: feat: configure navigation targets for errors
+- a7ae066: feat: add navigation target support to error recovery
+
+## 테스트 방법
+
+1. 타입 체크
+
+   - 잘못된 경로를 `navigationTarget`으로 지정할 경우 타입 에러 발생 확인
+   - 올바른 경로 지정 시 타입 에러 없음 확인
+
+2. 기능 테스트
+   - UnauthorizedError 발생 시 `/login` 페이지로 이동
+   - ForbiddenError 발생 시 `/` 페이지로 이동
+   - BadRequestError 발생 시 `/` 페이지로 이동

--- a/hooks/useRecoverFromError.ts
+++ b/hooks/useRecoverFromError.ts
@@ -10,18 +10,13 @@ export const useRecoverFromError = () => {
   const clearTokens = useSetAtom(authActions.clearTokens);
 
   const recoverFromError = useCallback(
-    async (details: {
-      reason: 'imperative-api';
-      args: [ResetOptions] | [];
-    }) => {
-      if (details.reason !== 'imperative-api') return;
-
+    async (resetOptions: ResetOptions) => {
       const {
         shouldClearCache = true,
         shouldClearAuth = false,
         shouldClearNavigation = true,
         navigationTarget = '/',
-      } = details.args[0] || {};
+      } = resetOptions;
 
       if (shouldClearCache) {
         queryClient.clear();
@@ -32,7 +27,7 @@ export const useRecoverFromError = () => {
       }
 
       if (shouldClearNavigation) {
-        router.replace(navigationTarget);
+        router.replace(navigationTarget as '/login' | '/');
       }
     },
     [queryClient, clearTokens]

--- a/hooks/useRecoverFromError.ts
+++ b/hooks/useRecoverFromError.ts
@@ -27,7 +27,7 @@ export const useRecoverFromError = () => {
       }
 
       if (shouldClearNavigation) {
-        router.replace(navigationTarget as '/login' | '/');
+        router.replace(navigationTarget);
       }
     },
     [queryClient, clearTokens]

--- a/lib/errors/http.ts
+++ b/lib/errors/http.ts
@@ -4,12 +4,13 @@ import {
   type KyResponse,
   type KyRequest,
 } from 'ky';
+import type { Route } from 'expo-router/build/types';
 
 export interface ResetOptions {
   shouldClearCache?: boolean;
   shouldClearAuth?: boolean;
   shouldClearNavigation?: boolean;
-  navigationTarget?: string;
+  navigationTarget?: Route;
 }
 
 export class UnauthorizedError extends HTTPError {


### PR DESCRIPTION
## 개요

에러 복구 시 네비게이션 처리에 expo-router의 Route 타입을 적용하여 타입 안전성을 개선했습니다.

## 주요 변경사항

### 1. expo-router Route 타입 적용

- `ResetOptions`의 `navigationTarget` 타입을 string에서 expo-router의 Route 타입으로 변경
- 타입 안전성 확보로 잘못된 경로 지정 방지
- 자동 완성 지원으로 개발 편의성 향상

### 2. 타입 캐스팅 제거

- `useRecoverFromError` 훅에서 불필요한 타입 캐스팅 제거
- 타입 시스템을 통한 경로 유효성 검증

## 기대효과

- 잘못된 경로로의 네비게이션 시도를 컴파일 타임에 방지
- 리팩토링 시 경로 변경에 대한 안전성 확보
- 개발자 경험 개선 (자동 완성, 타입 체크)

## 커밋 히스토리

- a6630ed: feat: configure navigation targets for errors
- a7ae066: feat: add navigation target support to error recovery

## 테스트 방법

1. 타입 체크

   - 잘못된 경로를 `navigationTarget`으로 지정할 경우 타입 에러 발생 확인
   - 올바른 경로 지정 시 타입 에러 없음 확인

2. 기능 테스트
   - UnauthorizedError 발생 시 `/login` 페이지로 이동
   - ForbiddenError 발생 시 `/` 페이지로 이동
   - BadRequestError 발생 시 `/` 페이지로 이동
