### PR TITLE
# Switch from Google OAuth to Firebase ID Token

### DIFF
--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,9 +1,9 @@
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
+import auth from '@react-native-firebase/auth';
 
 GoogleSignin.configure({
   scopes: ['email', 'profile'],
-  webClientId:
-    '425832297557-7serit12s908077334e928rclpdu6uqm.apps.googleusercontent.com',
+  webClientId: process.env.EXPO_PUBLIC_FIREBASE_WEB_CLIENT_ID,
   offlineAccess: true,
 });
 
@@ -11,7 +11,12 @@ export const signInWithGoogle = async () => {
   await GoogleSignin.hasPlayServices();
   await GoogleSignin.signIn();
   const { idToken } = await GoogleSignin.getTokens();
-  return idToken;
+
+  const credential = auth.GoogleAuthProvider.credential(idToken);
+
+  const userCredential = await auth().signInWithCredential(credential);
+  const firebaseIdToken = await userCredential.user.getIdToken(true);
+  return firebaseIdToken;
 };
 
 export const signOutFromGoogle = async () => {


### PR DESCRIPTION
## Description

Changes the authentication flow to use Firebase ID tokens instead of Google OAuth tokens. This ensures our backend receives tokens in the Firebase-specified format for proper authentication verification.

## Changes

- Modified `signInWithGoogle` to retrieve Firebase ID token after Google authentication
- Added Firebase credential creation and sign-in step
- Now returns Firebase ID token instead of Google OAuth token

## Testing

- Verified complete authentication flow with Firebase
- Confirmed proper token format for backend verification

## Related Issues

Switches from Google OAuth ID token to Firebase ID token format for backend compatibility
