### PR TITLE
Query Provider 이름 개선

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,14 +1,14 @@
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
-import { Providers } from '@/lib/react-query';
+import { QueryProvider } from '@/lib/react-query';
 import { TamaguiProvider } from 'tamagui';
 import appConfig from '@/tamagui.config';
 
 export default function RootLayout() {
   return (
     <TamaguiProvider config={appConfig}>
-      <Providers>
+      <QueryProvider>
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="+not-found" />
@@ -16,7 +16,7 @@ export default function RootLayout() {
           <Stack.Screen name="chat" />
         </Stack>
         <StatusBar style="light" />
-      </Providers>
+      </QueryProvider>
     </TamaguiProvider>
   );
 }

--- a/documents/rename-query-provider-pr.md
+++ b/documents/rename-query-provider-pr.md
@@ -1,0 +1,34 @@
+# Query Provider 이름 개선
+
+## 개요
+
+`Providers` 컴포넌트의 이름을 `QueryProvider`로 변경하여 컴포넌트의 실제 역할을 더 명확하게 표현했습니다.
+
+## 변경 사항
+
+### 1. 컴포넌트 이름 변경
+
+- `Providers` → `QueryProvider`로 변경
+- 인터페이스 이름도 `QueryProviderProps`로 일관성 있게 변경
+- 실제 기능 변경 없음
+
+### 2. 임포트 업데이트
+
+- `app/_layout.tsx`의 임포트 구문 업데이트
+- JSX 내 컴포넌트 사용 부분 업데이트
+
+## 변경 이유
+
+- 컴포넌트가 실제로는 Query 관련 설정만 담당하고 있어서, 이름을 더 구체적으로 변경
+- `TamaguiProvider`와 같은 다른 Provider 컴포넌트들의 네이밍 패턴과 일치
+- 불필요한 'Client' 키워드 제거로 간결성 향상
+
+## 테스트
+
+- 기존 쿼리 기능이 정상적으로 동작하는지 확인
+- 개발 환경에서 React Query DevTools가 정상적으로 표시되는지 확인
+
+## 관련 커밋
+
+- refactor: rename QueryClientProvider to QueryProvider
+- refactor: update QueryProvider imports

--- a/lib/react-query.tsx
+++ b/lib/react-query.tsx
@@ -1,13 +1,16 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  QueryClient,
+  QueryClientProvider as TanstackQueryClientProvider,
+} from '@tanstack/react-query';
 import { DevToolsBubble } from 'react-native-react-query-devtools';
 import { ReactNode } from 'react';
 import * as Clipboard from 'expo-clipboard';
 
-interface ProvidersProps {
+interface QueryClientProviderProps {
   children: ReactNode;
 }
 
-export function Providers({ children }: ProvidersProps) {
+export function QueryClientProvider({ children }: QueryClientProviderProps) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -30,11 +33,11 @@ export function Providers({ children }: ProvidersProps) {
   };
 
   return (
-    <QueryClientProvider client={queryClient}>
+    <TanstackQueryClientProvider client={queryClient}>
       {children}
       {process.env.NODE_ENV === 'development' && (
         <DevToolsBubble onCopy={onCopy} />
       )}
-    </QueryClientProvider>
+    </TanstackQueryClientProvider>
   );
 }

--- a/lib/react-query.tsx
+++ b/lib/react-query.tsx
@@ -1,16 +1,13 @@
-import {
-  QueryClient,
-  QueryClientProvider as TanstackQueryClientProvider,
-} from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { DevToolsBubble } from 'react-native-react-query-devtools';
 import { ReactNode } from 'react';
 import * as Clipboard from 'expo-clipboard';
 
-interface QueryClientProviderProps {
+interface QueryProviderProps {
   children: ReactNode;
 }
 
-export function QueryClientProvider({ children }: QueryClientProviderProps) {
+export function QueryProvider({ children }: QueryProviderProps) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -33,11 +30,11 @@ export function QueryClientProvider({ children }: QueryClientProviderProps) {
   };
 
   return (
-    <TanstackQueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
       {children}
       {process.env.NODE_ENV === 'development' && (
         <DevToolsBubble onCopy={onCopy} />
       )}
-    </TanstackQueryClientProvider>
+    </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## 개요

`Providers` 컴포넌트의 이름을 `QueryProvider`로 변경하여 컴포넌트의 실제 역할을 더 명확하게 표현했습니다.

## 변경 사항

### 1. 컴포넌트 이름 변경

- `Providers` → `QueryProvider`로 변경
- 인터페이스 이름도 `QueryProviderProps`로 일관성 있게 변경
- 실제 기능 변경 없음

### 2. 임포트 업데이트

- `app/_layout.tsx`의 임포트 구문 업데이트
- JSX 내 컴포넌트 사용 부분 업데이트

## 변경 이유

- 컴포넌트가 실제로는 Query 관련 설정만 담당하고 있어서, 이름을 더 구체적으로 변경
- `TamaguiProvider`와 같은 다른 Provider 컴포넌트들의 네이밍 패턴과 일치
- 불필요한 'Client' 키워드 제거로 간결성 향상

## 테스트

- 기존 쿼리 기능이 정상적으로 동작하는지 확인
- 개발 환경에서 React Query DevTools가 정상적으로 표시되는지 확인

## 관련 커밋

- refactor: rename QueryClientProvider to QueryProvider
- refactor: update QueryProvider imports
