### PR TITLE
ci: add bun global bin to PATH after global CLI install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
       - name: 📦 Install EAS CLI (fork)
         run: bun add -g sleppy-navigators/eas-cli
 
+      - name: ➕ Add bun global bin to PATH
+        run: echo "${HOME}/.bun/bin" >> $GITHUB_PATH
+
       - name: 🛠 Patch ENOSPC (Ubuntu only)
         if: runner.os == 'Linux'
         run: sudo sysctl fs.inotify.max_user_watches=524288


### PR DESCRIPTION
## What
- Add a workflow step to include bun's global bin directory (`${HOME}/.bun/bin`) in the PATH after installing global CLI tools.

## Why
- Fixes `eas: command not found` error in CI by ensuring all bun-installed global CLIs are available in subsequent workflow steps.

## Details
- Adds a step after installing `expo-cli` and `eas-cli` to update the PATH for the rest of the workflow.
- No app code changes, only CI workflow update.

## Checklist
- [x] Workflow tested and `eas` command is now available in all steps
- [x] No breaking changes
