### PR TITLE
완전한 CD가 되도록 워크플로우 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,11 @@
-name: Build App
+name: Release App
 on:
-  workflow_dispatch:
-    inputs:
-      os:
-        type: choice
-        description: OS to build on. Ubuntu is faster, MacOS supports iOS builds
-        options:
-          - macos-latest
-          - ubuntu-latest
-      platform:
-        type: choice
-        description: Platform to build for
-        options:
-          - android
-          - ios
-      profile:
-        type: choice
-        description: Build profile to use
-        options:
-          - development
-          - preview
-          - production
-      should_submit:
-        type: boolean
-        description: Whether to perform the submit step
-        required: true
-        default: false
+  push:
+    branches:
+      - main
 jobs:
   build:
-    runs-on: ${{ github.event.inputs.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
@@ -86,13 +63,12 @@ jobs:
       #   run: bun test
 
       - name: 👷 Build Android app
-        if: ${{ github.event.inputs.platform == 'android' }}
         run: |
           eas build --local \
             --non-interactive \
             --output=./output.aab \
-            --platform=${{ github.event.inputs.platform }} \
-            --profile=${{ github.event.inputs.profile }}
+            --platform=android \
+            --profile=production
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
@@ -104,7 +80,6 @@ jobs:
           bundler-cache: true
 
       - name: 🚀 Upload to Google Play (Fastlane)
-        if: ${{ github.event.inputs.platform == 'android' && github.event.inputs.should_submit }}
         uses: maierj/fastlane-action@v3.1.0
         with:
           lane: run supply


### PR DESCRIPTION
## Summary

기존에 사용하던 `build.yml` CI 워크플로우를 새롭게 `release.yml`로 교체했습니다. 이제 `main` 브랜치에 푸시가 발생하면, 안드로이드 앱을 자동으로 빌드하고 Google Play에 업로드하는 릴리즈 프로세스가 한 번에 진행됩니다. 이번 변경을 통해 CI/CD 과정이 더욱 명확해지고, 관리와 유지보수가 쉬워졌습니다.

- 관련 이슈: 없음

## PR 유형 및 세부 작업 내용

- [x] 빌드 및 패키지 매니저 관련 수정
- [x] 파일 및 폴더명 변경
- [x] 파일 및 폴더 삭제

- 기존 `build.yml` 워크플로우를 삭제하고, `release.yml`로 대체했습니다.
- Bun 환경 설정, 의존성 설치, EAS를 활용한 안드로이드 앱 로컬 빌드, Fastlane을 통한 Google Play 업로드가 자동화되었습니다.
- 보안 강화를 위해 크리덴셜 및 키스토어 디코딩 단계를 추가했습니다.
- 워크플로우는 오직 `main` 브랜치에 푸시될 때만 실행됩니다.
- 로컬 빌드 및 Play Store 업로드를 위한 Ruby, Android SDK 설정도 포함되어 있습니다.

## test 완료 여부 (선택)

- [ ] 테스트 완료 (워크플로우 마이그레이션이므로 해당 없음)

## 작동 스크린샷 (선택)

해당 없음

## 리뷰 요구사항 (선택)

- 새 워크플로우의 전체 동작과 시크릿 관리가 안전하게 이루어지는지 중점적으로 확인 부탁드립니다.
