### PR TITLE
Storybook 및 MSW 코드가 비활성화 시 import되지 않도록 개선

### DIFF
--- a/documents/pull-requests/2025-06-06-fix-avoid-storybook-top-level-import.md
+++ b/documents/pull-requests/2025-06-06-fix-avoid-storybook-top-level-import.md
@@ -1,0 +1,24 @@
+## Summary
+
+Storybook이 비활성화된 경우, 관련 엔트리 포인트 코드가 아예 import되거나 실행되지 않도록 개선했습니다. 이를 통해 불필요한 top-level 코드 실행 및 side effect를 방지하고, 빌드 성능과 안정성을 높였습니다.
+
+## PR 유형 및 세부 작업 내용
+
+- [x] 버그 수정
+
+### 세부 내용
+
+- 기존에는 StorybookProvider가 항상 StorybookUIRoot를 import하여, storybookEnabled 값과 무관하게 top-level 코드가 실행되는 문제가 있었습니다. 따라서 msw가 초기화되어 프로덕션 환경에서 제대로 요청을 수행할 없었습니다.
+- storybookEnabled가 true일 때만 require를 통해 StorybookUIRoot를 동적으로 import하도록 변경했습니다.
+- 이에 따라 storybook이 비활성화된 환경에서는 관련 코드가 아예 import되지 않아, side effect 및 빌드 최적화에 도움이 됩니다.
+
+## 테스트 완료 여부
+
+- storybookEnabled가 false일 때 Storybook 관련 코드가 import되지 않는 것을 확인했습니다.
+- storybookEnabled가 true일 때 정상적으로 Storybook이 동작하는 것도 확인했습니다.
+
+## 스크린샷 (선택)
+
+## 리뷰 요청 사항
+
+- 혹시 놓친 side effect나 추가적으로 고려해야 할 부분이 있다면 코멘트 부탁드립니다.

--- a/domains/base/providers/storybook-provider.tsx
+++ b/domains/base/providers/storybook-provider.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import Constants from 'expo-constants';
-import StorybookUIRoot from '../../../.storybook';
 
-export default function StorybookProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const isStorybookEnabled = Constants.expoConfig?.extra?.storybookEnabled;
+const isStorybookEnabled = Constants.expoConfig?.extra?.storybookEnabled;
 
-  if (isStorybookEnabled) {
-    return <StorybookUIRoot />;
-  }
-
+function App({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
+
+let AppEntryPoint = App;
+
+if (isStorybookEnabled) {
+  const { default: StorybookUIRoot } = require('@/.storybook');
+  AppEntryPoint = StorybookUIRoot;
+}
+
+export default AppEntryPoint;


### PR DESCRIPTION
## Summary

Storybook이 비활성화된 경우, 관련 엔트리 포인트 코드가 아예 import되거나 실행되지 않도록 개선했습니다. 이를 통해 불필요한 top-level 코드 실행 및 side effect를 방지하고, 빌드 성능과 안정성을 높였습니다.

## PR 유형 및 세부 작업 내용

- [x] 버그 수정

### 세부 내용

- 기존에는 StorybookProvider가 항상 StorybookUIRoot를 import하여, storybookEnabled 값과 무관하게 top-level 코드가 실행되는 문제가 있었습니다. 따라서 msw가 초기화되어 프로덕션 환경에서 제대로 요청을 수행할 없었습니다.
- storybookEnabled가 true일 때만 require를 통해 StorybookUIRoot를 동적으로 import하도록 변경했습니다.
- 이에 따라 storybook이 비활성화된 환경에서는 관련 코드가 아예 import되지 않아, side effect 및 빌드 최적화에 도움이 됩니다.

## 테스트 완료 여부

- storybookEnabled가 false일 때 Storybook 관련 코드가 import되지 않는 것을 확인했습니다.
- storybookEnabled가 true일 때 정상적으로 Storybook이 동작하는 것도 확인했습니다.

## 스크린샷 (선택)

## 리뷰 요청 사항

- 혹시 놓친 side effect나 추가적으로 고려해야 할 부분이 있다면 코멘트 부탁드립니다.
