### PR TITLE
프로덕션 빌드 시 Storybook 모듈 그래프 에러 해결 (Custom Build Step 적용)

### DIFF
--- a/.eas/build/build.yml
+++ b/.eas/build/build.yml
@@ -1,0 +1,18 @@
+build:
+  name: Android Production Build with Storybook Requires Generation
+  steps:
+    - eas/checkout
+
+    - eas/install_node_modules
+
+    - run:
+        name: Generate storybook.requires.ts
+        command: bun run storybook-generate
+
+    - eas/prebuild
+
+    - eas/inject_android_credentials
+
+    - eas/run_gradle
+
+    - eas/find_and_upload_build_artifacts

--- a/documents/pull-requests/2024-06-06-storybook-eager-build-fix.md
+++ b/documents/pull-requests/2024-06-06-storybook-eager-build-fix.md
@@ -1,0 +1,19 @@
+## Summary
+
+프로덕션 빌드 시 발생하는 Storybook 모듈 그래프 에러를 custom build step으로 해결했습니다.
+
+(There are no new commits on this branch compared to main.)
+
+## PR 유형 및 세부 작업 내용
+
+- [x] 빌드 부분 혹은 패키지 매니저 수정
+- [x] 문서 수정
+
+- eas build에서 Storybook 관련 에러 해결
+- custom build step 추가로 storybook.required.ts 생성 자동화
+
+## 추가 내용
+
+1. 빌드 타임에 withStorybook에 enabled: false 옵션을 사용하면, eas build 시 storybook.required.ts가 생성되지 않아 module graph를 그릴 때 @index.tsx에서 { view } 모듈을 찾을 수 없다는 에러가 발생하였습니다.
+2. 이는 eas build에서 빌드 시 모든 파일을 포함하는 eager build 방식을 사용하기 때문이었습니다.
+3. 해결 방법: custom build step을 eas.json에 정의하여, 빌드 과정에서 storybook.required.ts를 생성하는 step을 추가하였습니다.

--- a/eas.json
+++ b/eas.json
@@ -34,6 +34,7 @@
         "APP_VARIANT": "production"
       },
       "android": {
+        "config": "build.yml",
         "credentialsSource": "local"
       },
       "channel": "production"

--- a/metro.config.js
+++ b/metro.config.js
@@ -8,6 +8,10 @@ const withStorybook = require('@storybook/react-native/metro/withStorybook');
 const config = getDefaultConfig(__dirname);
 
 const customConfig = mergeConfig(config, {
+  transformer: {
+    unstable_allowRequireContext: true,
+  },
+
   resolver: {
     unstable_enablePackageExports: true,
     resolverMainFields: ['react-native', 'node', 'browser', 'main'],

--- a/metro.config.js
+++ b/metro.config.js
@@ -17,9 +17,11 @@ const customConfig = mergeConfig(config, {
 const withStorybookConfig = withStorybook(customConfig, {
   // Set to false to remove storybook specific options
   // you can also use a env variable to set this
-  enabled: process.env.STORYBOOK_ENABLED,
+  enabled: !!process.env.STORYBOOK_ENABLED,
   // Path to your storybook config
   configPath: path.resolve(__dirname, './.storybook'),
+
+  onDisabledRemoveStorybook: !process.env.STORYBOOK_ENABLED,
 
   // Optional websockets configuration
   // Starts a websocket server on the specified port and host on metro start

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "eas build --profile development",
     "preview": "eas build --profile preview",
-    "prod": "eas build --profile production",
+    "prod": "storybook-generate && eas build --profile production",
+    "prod:android": "eas build --local --non-interactive --output=./output.aab --platform=android --profile=production",
     "start": "cross-env APP_VARIANT=development expo start --dev-client --clear",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "cross-env APP_VARIANT=development expo run:android",


### PR DESCRIPTION
## Summary

프로덕션 빌드 시 발생하는 Storybook 모듈 그래프 에러를 custom build step으로 해결했습니다.

(There are no new commits on this branch compared to main.)

## PR 유형 및 세부 작업 내용

- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 문서 수정

- eas build에서 Storybook 관련 에러 해결
- custom build step 추가로 storybook.required.ts 생성 자동화

## 추가 내용

1. 빌드 타임에 withStorybook에 enabled: false 옵션을 사용하면, eas build 시 storybook.required.ts가 생성되지 않아 module graph를 그릴 때 @index.tsx에서 { view } 모듈을 찾을 수 없다는 에러가 발생하였습니다.
2. 이는 eas build에서 빌드 시 모든 파일을 포함하는 eager build 방식을 사용하기 때문이었습니다.
3. 해결 방법: custom build step을 eas.json에 정의하여, 빌드 과정에서 storybook.required.ts를 생성하는 step을 추가하였습니다.
